### PR TITLE
Templates: Remove obsolete database_hash parameter

### DIFF
--- a/templates/500.html
+++ b/templates/500.html
@@ -9,7 +9,7 @@
 {% endif %}
 
 {% if database %}
-    <form class="sql" action="/{{ database }}-{{ database_hash }}" method="get">
+    <form class="sql" action="/{{ database }}" method="get">
         <h3>Custom SQL query</h3>
 
         <p><textarea name="sql"></textarea></p>

--- a/templates/base.html
+++ b/templates/base.html
@@ -83,7 +83,7 @@
   <section id="salary-content">
       {% if table %}
         <h2 class="sub-title">
-          <a href="/{{ database }}-{{ database_hash }}/{{ table|quote_plus }}">{{ table }}</a>
+          <a href="/{{ database }}/{{ table|quote_plus }}">{{ table }}</a>
         </h2>
       {% endif %}
       <h1 class="title"><a href="/">{{ site_info.siteTitle }}</a></h1>

--- a/templates/database.html
+++ b/templates/database.html
@@ -5,7 +5,7 @@
 {% block body_class %}db db-{{ database|to_css_class }}{% endblock %}
 
 {% block content %}
-<form class="sql" action="/{{ database }}-{{ database_hash }}" method="get">
+<form class="sql" action="/{{ database }}" method="get">
     <h3>Custom SQL query</h3>
     <p>Note: Database uses <a href="https://www.sqlite.org/lang.html">SQLite</a> syntax.</p>
     <p><textarea name="sql">SELECT * FROM "2018 Maryland state salaries";</textarea></p>
@@ -18,7 +18,7 @@
         {% for query in queries %}
             <li>
                 <p>
-                    <a href="/{{ database }}-{{ database_hash }}/{{ query.name }}" title="{{ query.sql }}">{{ query.name.replace("-", " ").title() }}</a>
+                    <a href="/{{ database }}/{{ query.name }}" title="{{ query.sql }}">{{ query.name.replace("-", " ").title() }}</a>
                 </p>
                 <p>
                     <textarea class="sql" disabled>{{ query.sql }}</textarea>

--- a/templates/query.html
+++ b/templates/query.html
@@ -45,7 +45,7 @@
 {% endif %}
 
 {% if not canned_query %}
-<form class="sql" action="/{{ database }}-{{ database_hash }}" method="get">
+<form class="sql" action="/{{ database }}" method="get">
     <h3>Custom SQL query{% if rows %} returning {% if truncated %}more than {% endif %}{{ "{:,}".format(rows|length) }} row{% if rows|length == 1 %}{% else %}s{% endif %}{% endif %}</h3>
     {% if editable %}
         <p><textarea name="sql">{% if query and query.sql %}{{ query.sql }}{% else %}select * from {{ tables[0].name|escape_sqlite }}{% endif %}</textarea></p>

--- a/templates/table.html
+++ b/templates/table.html
@@ -9,7 +9,7 @@
 
 {% block content %}
 
-<form class="filters" action="/{{ database }}-{{ database_hash }}/{{ table|quote_plus }}" method="get">
+<form class="filters" action="/{{ database }}/{{ table|quote_plus }}" method="get">
 
     {% if supports_search %}
         <div class="dbsearch search-table"><label for="_search">Search:</label><input id="_search" type="search" name="_search" value="{{ search }}"></div>


### PR DESCRIPTION
It was removed from Datasette 0.28 so it doesn't do anything anymore.